### PR TITLE
Exported methods calling wrong functions: GetIPO, GetLocations

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = {
     return getFundRaiseUrl(uuid, callback);
   },
   locations: function(params) {
-    return getLocationsUrl(params, callback);
+    return getLocations(params, callback);
   },
   catagories: function(params) {
     return getCatagoriesUrl(params);

--- a/index.js
+++ b/index.js
@@ -106,15 +106,15 @@ module.exports = {
     return getAcquisition(uuid, callback);
   },
   ipo: function(uuid) {
-    return getIPOUrl(uuid, callback);
+    return getIPO(uuid, callback);
   },
   fundRaise: function(uuid) {
-    return getFundRaiseUrl(uuid, callback);
+    return getFundRaise(uuid, callback);
   },
   locations: function(params) {
     return getLocations(params, callback);
   },
   catagories: function(params) {
-    return getCatagoriesUrl(params);
+    return getCatagories(params);
   }
 }


### PR DESCRIPTION
There were a couple of typos in the exported methods for some of the lesser-used function calls in the API. Fixed those so they're working now.